### PR TITLE
Fix OnScreenKeyboard not showing automatically

### DIFF
--- a/SearchActivity.cs
+++ b/SearchActivity.cs
@@ -58,6 +58,7 @@ namespace com.aa.tvshows
             list.ClearOnScrollListeners();
             var layoutManager = new CachingLayoutManager(this);
             list.SetLayoutManager(layoutManager);
+            editText.RequestFocus();
             editText.QueryTextChange += async (s, e) =>
             {
                 // get data from suggestions


### PR DESCRIPTION
When searching for something OnScreenKeyboard does not pop-up automatically. This fixes that issue.